### PR TITLE
fix: revert "Bump commander from 2.20.3 to 10.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@beauraines/rtm-api": "^1.6.0",
         "chalk": "^4.0.0",
         "cli-table3": "^0.6.3",
-        "commander": "^10.0.0",
+        "commander": "^2.11.0",
         "copy-paste": "^1.3.0",
         "dateformat": "^4.0.0",
         "debug": "^4.3.4",
@@ -2213,12 +2213,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/commander": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/compare-func": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@beauraines/rtm-api": "^1.6.0",
     "chalk": "^4.0.0",
     "cli-table3": "^0.6.3",
-    "commander": "^10.0.0",
+    "commander": "^2.11.0",
     "copy-paste": "^1.3.0",
     "dateformat": "^4.0.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
Reverts beauraines/rtm-cli#34

Something broke in how arguments are passed from the command line when upgrading to 10.0.0. I tried to fix this in #58 but this didn't work.

I'll need to come back and upgrade this dependency manually.

Fix #59 