### PR TITLE
feat: login workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,34 @@ For full documentation on the usage of the built-in commands and options,
 see the [Command Reference](https://github.com/dwaring87/rtm-cli/wiki/Command-Reference).
 
 
+### Troubleshooting
+
+For new users without a `.rtm.json` file, there is an issue preventing the CLI to wait for you to 
+authenticate to RTM in your browser before attempting to login with your token. As a work around,
+you can run the following command from the projects root, once you clone this repo.
+
+It is a two step process, to get a `frob` and authenticate with RTM and then the second step uses
+the `frob` to request a token that gets saved to your `.rtm.json` file.
+
+First,  run `node src/utils/login-workaround-step1.js` You will get an RTM login link and a frob to
+use in the next command
+
+```shell
+Authenticate with RTM by opening the link in your web browser
+https://www.rememberthemilk.com/services/auth/?api_key=cbc762cxxxxxccc4ee1f&perms=delete&frob=8fccccccccc3fbc1df9d5&api_sig=3becccccccccccc305db82b2a
+Once you've authenticated, run the following command
+node src/utils/login-workaround-step2.js  8f49634xxxxxxxxxxxxxxxfd03fbc1df9d5
+Warning! This wil overwrite an existing ~/.rtm.json if you have one.
+```
+
+Then run the command it gives you `node src/utils/login-workaround-step2.js <frob>` and it will get 
+your auth token and save it to `~/.rtm.json`. 
+
+Change the permissions on your `~/.rtm.json` to owner ownly `chmod 600`
+
+With an `~/.rtm.json` you should now be able to use RTM CLI.
+
+
 ## Configuration
 
 RTM CLI has a number of properties that can be configured using a separate JSON configuration

--- a/src/utils/login-workaround-step1.js
+++ b/src/utils/login-workaround-step1.js
@@ -1,0 +1,27 @@
+const api = require('@beauraines/rtm-api');
+
+const CLIENT = {
+      apiKey: "cbc76268b901ccb8d9fc5f3aebc4ee1f",
+      apiSecret: "131beea786379309",
+      perms: "delete"
+    }
+
+const main = async () => {
+    const client = new api(
+        CLIENT.apiKey,
+        CLIENT.apiSecret,
+        CLIENT.perms
+    )    ;
+
+    client.auth.getAuthUrl(function(err,url,frob) {
+        console.log('Authenticate with RTM by opening the link in your web browser');
+        console.log(url);
+        console.log(`Once you've authenticated, run the following commmand`);
+        console.log(`node src/utils/login-workaround-step2.js  ${frob}`);
+        console.log(`Warning! This wil overwrite an existing ~/.rtm.json if you have one.`)
+    })
+
+    
+}
+
+main()

--- a/src/utils/login-workaround-step2.js
+++ b/src/utils/login-workaround-step2.js
@@ -1,0 +1,57 @@
+const api = require('@beauraines/rtm-api');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+
+const CLIENT = {
+      apiKey: "cbc76268b901ccb8d9fc5f3aebc4ee1f",
+      apiSecret: "131beea786379309",
+      perms: "delete"
+    }
+
+const main = async () => {
+    const client = new api(
+        CLIENT.apiKey,
+        CLIENT.apiSecret,
+        CLIENT.perms
+    )    ;
+
+
+    const args = process.argv.slice(2).length > 0 ? process.argv.slice(2) : []
+    if (args.length == 0) {
+        console.error("You must include a frob");
+        process.exit(1);
+    }
+
+    const frob = args[0];
+    
+    client.auth.getAuthToken(frob,function(err,user){
+            if ( err ) {
+                console.error('Could not Log In (' + err.msg + ')');
+                process.exit(1);
+            }
+        console.log('Logged in As: ' + user.username);
+        console.log(userToConfig(user));
+
+        const filePath = path.normalize(os.homedir() + '/' + '.rtm.json');
+        fs.writeFileSync(filePath,JSON.stringify(userToConfig(user)),{ encoding: 'utf8' });
+    })
+    
+}
+
+main()
+
+
+const userToConfig = (user) => {
+    const config ={};
+    config.user = {
+        id: user._id,
+        username: user._username,
+        fullname: user._fullname,
+        authToken: user._authToken,
+        client: CLIENT,
+        timeline: user._timeline
+    }
+    return config;
+}


### PR DESCRIPTION
Creates work around commands to generate an .rtm.json configuration file

For new users without a `.rtm.json` file, there is an issue preventing the CLI to wait for you to authenticate to RTM in your browser before attempting to login with your token. As a work around, you can run the following command from the projects root, once you clone this repo.

It is a two step process, to get a `frob` and authenticate with RTM and then the second step uses the `frob` to request a token that gets saved to your `.rtm.json` file.

First,  run `node src/utils/login-workaround-step1.js` You will get an RTM login link and a frob to use in the next command

```shell
Authenticate with RTM by opening the link in your web browser
https://www.rememberthemilk.com/services/auth/?api_key=cbc762cxxxxxccc4ee1f&perms=delete&frob=8fccccccccc3fbc1df9d5&api_sig=3becccccccccccc305db82b2a
Once you've authenticated, run the following command
node src/utils/login-workaround-step2.js  8f49634xxxxxxxxxxxxxxxfd03fbc1df9d5
Warning! This wil overwrite an existing ~/.rtm.json if you have one.
```

Then run the command it gives you `node src/utils/login-workaround-step2.js <frob>` and it will get your auth token and save it to `~/.rtm.json`.

Change the permissions on your `~/.rtm.json` to owner ownly `chmod 600`

With an `~/.rtm.json` you should now be able to use RTM CLI.