### PR TITLE
fix: properly handles empty location tag, file name written to std err

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,5 +176,5 @@ and `rtm obsidian 4330` would output
 which could be written to a file in your Obsidian Vault.
 
 ```shell
-rtm ls due:today | cut -wf1 | sort | xargs ./src/cli.js obsidian >> ~/LocalDocs/Test/Tasks/rtm.md
+rtm ls due:today | cut -wf1 | sort | xargs rtm obsidian >> ~/LocalDocs/Test/Tasks/rtm.md
 ```

--- a/src/cmd/obsidian.js
+++ b/src/cmd/obsidian.js
@@ -90,8 +90,9 @@ function displayObsidianTask(idx, task) {
   task.list_name = listName;
 
   const location = LOCATION_MAP.get(location_id)
-  const locationName = location?.name || "Not found";
-  const locationTag = 'location/'+locationName.replace(/\s+/g, '-');
+  const locationName = location?.name;
+  let locationTag ='';
+  locationName ? locationTag = '#location/'+locationName.replace(/\s+/g, '-') : null ;
   task.location = location;
 
 
@@ -147,7 +148,7 @@ function displayObsidianTask(idx, task) {
   }
 
   // Add list tag first, then other tags
-  const allTags = [`#${listTag}`, `#${locationTag}`, ...tags.map(t => `#${sanitizeTag(t)}`)];
+  const allTags = [`#${listTag}`, `${locationTag}`, ...tags.map(t => `#${sanitizeTag(t)}`)];
   const tagStr = allTags.map(t => ` ${t}`).join('');
   line += `${tagStr}`;
 
@@ -265,6 +266,8 @@ function exportDetails(idx, task) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   try {
     fs.writeFileSync(filePath, content);
+    console.error(`Task detail files written to ${filePath}`)
+
   } catch (e) {
     console.error(`Failed to write details file for task ${idx}: ${e}`);
   }


### PR DESCRIPTION
- fixes issue where location tags were beign writtten `location/No-Location` for tasks without a location,
now nothing is written
- Outputs the filename to stderr, so redirects still work and you can find the file now
- updates command reference in README
